### PR TITLE
fix(public-service): resolve payer UUID so SEND_TO_CITIZEN_PAYMENT succeeds

### DIFF
--- a/studio-services/public-service/service/enrichment_service.go
+++ b/studio-services/public-service/service/enrichment_service.go
@@ -164,12 +164,20 @@ func (s *EnrichmentService) EnrichApplicationsWithDemand(apps model.ApplicationR
 	// Step 5: Get Payer Info
 	var payerUser model.User
 	if len(apps.Application.Applicants) > 0 {
-		individualId := apps.Application.Applicants[0].UserId
+		applicant := apps.Application.Applicants[0]
+
+		// Attempt to enrich payer from the Individual service. Pass the real
+		// RequestInfo so the Individual service accepts the auth context — passing
+		// an empty RequestInfo{} used to silently return zero results, which caused
+		// the payer UUID to default to 00000000-... and the billing service to
+		// reject the demand with EG_BS_USER_UUID_NOTFOUND.
+		individualId := applicant.UserId
 		criteria := map[string]interface{}{
 			"uuid":     individualId,
 			"tenantId": apps.Application.TenantId,
 		}
-		indResp := s.individualService.GetIndividual(model.RequestInfo{}, criteria)
+		indResp := s.individualService.GetIndividual(apps.RequestInfo, criteria)
+
 		if len(indResp.Individual) > 0 {
 			individual := indResp.Individual[0]
 			parsedUUID, err := uuid.Parse(individual.UserUuid)
@@ -186,6 +194,28 @@ func (s *EnrichmentService) EnrichApplicationsWithDemand(apps model.ApplicationR
 				TenantId:     individual.TenantId,
 				Type:         individual.UserDetails.Type,
 			}
+		} else if applicant.UserUuid != "" {
+			// Fallback: Individual service lookup came back empty (it can happen when
+			// the internal call runs without a privileged auth context). The applicant
+			// record already carries the citizen's UserUuid — use it directly so the
+			// billing demand still gets a non-zero payer UUID.
+			parsedUUID, err := uuid.Parse(applicant.UserUuid)
+			if err != nil {
+				log.Printf("Invalid UUID format for Applicant.UserUuid fallback: %v", err)
+				return apps, errors.New("Invalid UUID format for Applicant.UserUuid to enrich payer")
+			}
+			payerUser = model.User{
+				Uuid:         parsedUUID,
+				Name:         applicant.Name,
+				MobileNumber: strconv.FormatInt(applicant.MobileNumber, 10),
+				EmailId:      applicant.EmailId,
+				TenantId:     apps.Application.TenantId,
+				Type:         "CITIZEN",
+			}
+			log.Printf("Payer enriched from applicant.UserUuid fallback: %s", applicant.UserUuid)
+		} else {
+			log.Println("Cannot resolve payer: Individual lookup empty and applicant.UserUuid blank")
+			return apps, errors.New("Cannot resolve payer UUID for demand (empty individual lookup and blank applicant.UserUuid)")
 		}
 	} else {
 		log.Println("No applicants found to assign as payer")


### PR DESCRIPTION
## Summary
- Pass `apps.RequestInfo` (instead of empty `model.RequestInfo{}`) into the Individual service lookup inside `enrichment_service.go` so the internal auth context is actually propagated.
- Add a fallback: if the Individual lookup still returns no records, enrich the demand's payer from `applicant.UserUuid` (now populated at submit time by the frontend) instead of silently writing a zero UUID.
- If neither path yields a UUID, fail loud so billing never receives `00000000-0000-0000-0000-000000000000`.

## Why
When a BPA architect submits an application on behalf of a citizen and the Director later clicks **Envoyer au paiement citoyen**, the call failed with:

```
EG_BS_USER_UUID_NOTFOUND: No users found for following uuids [00000000-0000-0000-0000-000000000000]
```

Root cause (from the pod logs): `Step 5: Get Payer Info` in `service/enrichment_service.go` was calling `GetIndividual(model.RequestInfo{}, …)`. The empty `RequestInfo` stripped the auth context, the Individual service silently returned `[]`, and the Go zero-value UUID ended up on the `Demand.Payer`. Billing rejected it.

This blocked every paid application (PCO, PCO_SIMPLE, PL, PCS, PF, PS, ATARR) that was submitted by an architect on behalf of a citizen.

## Test plan
- [ ] Merge → CI (`staging-deployment.yaml`) builds `ttpldevops/public-service:latest-<timestamp>` and helm-upgrades the `public-service` deployment in `egov`.
- [ ] Log in as **Director**, open `PCO-SMPL-000031/2026`, click **Envoyer au paiement citoyen** → should succeed (bill created, application moves to `CITIZEN_PAYMENT_PENDING`).
- [ ] Log in as **Citizen** (LOULA) → Payments tab shows the real bill (replaces the costEstimation preview).
- [ ] Regression: citizen-self-submitted paid applications still work end to end.
- [ ] Regression: free services (BPA_PR, BPA_PD, BPA_CCR, BPA_CCE, BPA_CCP, BPA_CCG, BPA_PV, BPA_APE) unaffected — no demand created for them.